### PR TITLE
CK: fixed correct parsing of the ABI and compiler target string.

### DIFF
--- a/simulation/third_party/build_scripts/compile_hdf5.sh
+++ b/simulation/third_party/build_scripts/compile_hdf5.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-ABI=${1:-arm64-v8a}
-NDK=${2:-/home/martin/Android/Sdk/ndk/25.1.8937393}
+# ABI=${1:-arm64-v8a}
+# NDK=${2:-/home/martin/Android/Sdk/ndk/25.1.8937393}
+echo "Using ABI: ${ABI}"
+echo "Using NDK location: ${NDK}"
+echo "Using architecture: ${ARCH} (compiler prefix: ${COMPILER_PREFIX})"
 
 # Define NDK path and toolchain
-#export NDK=/home/martin/Android/Sdk/ndk/25.1.8937393
 export TOOLCHAIN=$NDK/toolchains/llvm/prebuilt/linux-x86_64
-export TARGET=$ABI-linux-android
+# export TARGET=$ABI-linux-android
+export TARGET=$COMPILER_PREFIX
 export API=21
 
 # Setup Compiler Variables
@@ -18,7 +21,7 @@ export RANLIB=$TOOLCHAIN/bin/llvm-ranlib
 export STRIP=$TOOLCHAIN/bin/llvm-strip
 
 # Setup Additional Flags
-export SYSROOT=$TOOLCHAIN/sysroot
+export SYSROOT="$TOOLCHAIN/sysroot"
 export CFLAGS="--sysroot $SYSROOT"
 export CXXFLAGS="--sysroot $SYSROOT"
 export LDFLAGS="--sysroot $SYSROOT -L$SYSROOT/usr/lib"
@@ -27,5 +30,5 @@ export CPPFLAGS="-I$SYSROOT/usr/include"
 
 cd ../hdf5/source
 ./configure --host=$TARGET --prefix=$SYSROOT/usr --with-zlib=$SYSROOT/usr --enable-shared --disable-static --enable-cxx
-make && make install
+make && make install && make clean
 cd ../../build_scripts

--- a/simulation/third_party/build_scripts/compile_netcdf.sh
+++ b/simulation/third_party/build_scripts/compile_netcdf.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-ABI=${1:-arm64-v8a}
-NDK=${2:-/home/martin/Android/Sdk/ndk/25.1.8937393}
+# ABI=${1:-arm64-v8a}
+# NDK=${2:-/home/martin/Android/Sdk/ndk/25.1.8937393}
+echo "Using ABI: ${ABI}"
+echo "Using NDK location: ${NDK}"
+echo "Using architecture: ${ARCH} (compiler prefix: ${COMPILER_PREFIX})"
 
 # Define NDK path and toolchain
-#export NDK=/home/martin/Android/Sdk/ndk/25.1.8937393
 export TOOLCHAIN=$NDK/toolchains/llvm/prebuilt/linux-x86_64
-export TARGET=$ABI-linux-android
+# export TARGET=$ABI-linux-android
+export TARGET=$COMPILER_PREFIX
 export API=21
 
 # Setup Compiler Variables

--- a/simulation/third_party/build_scripts/compile_netcdf_cxx.sh
+++ b/simulation/third_party/build_scripts/compile_netcdf_cxx.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-ABI=${1:-arm64-v8a}
-NDK=${2:-/home/martin/Android/Sdk/ndk/25.1.8937393}
+# ABI=${1:-arm64-v8a}
+# NDK=${2:-/home/martin/Android/Sdk/ndk/25.1.8937393}
+echo "Using ABI: ${ABI}"
+echo "Using NDK location: ${NDK}"
+echo "Using architecture: ${ARCH} (compiler prefix: ${COMPILER_PREFIX})"
 
-
-#export NDK=/home/martin/Android/Sdk/ndk/25.1.8937393
+# Define NDK path and toolchain
 export TOOLCHAIN=$NDK/toolchains/llvm/prebuilt/linux-x86_64
-export TARGET=$ABI-linux-android
+# export TARGET=$ABI-linux-android
+export TARGET=$COMPILER_PREFIX
 export API=21
 
 # Setup Compiler Variables

--- a/simulation/third_party/build_scripts/compile_vtk.sh
+++ b/simulation/third_party/build_scripts/compile_vtk.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
-ABI=${1:-arm64-v8a}
-NDK=${2:-/home/martin/Android/Sdk/ndk/25.1.8937393}
+# ABI=${1:-arm64-v8a}
+# NDK=${2:-/home/martin/Android/Sdk/ndk/25.1.8937393}
+echo "Using ABI: ${ABI}"
+echo "Using NDK location: ${NDK}"
+echo "Using architecture: ${ARCH} (compiler prefix: ${COMPILER_PREFIX})"
 
 # Define NDK path and toolchain
-#export NDK=/home/martin/Android/Sdk/ndk/25.1.8937393
 export TOOLCHAIN=$NDK/toolchains/llvm/prebuilt/linux-x86_64
-export TARGET=$ABI-linux-android
-export API=29
+# export TARGET=$ABI-linux-android
+export TARGET=$COMPILER_PREFIX
+# export API=29
+export API=21
 
 # Setup Compiler Variables
 export AR=$TOOLCHAIN/bin/llvm-ar

--- a/simulation/third_party/build_scripts/compile_zlib.sh
+++ b/simulation/third_party/build_scripts/compile_zlib.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
-ABI=${1:-arm64-v8a}
-NDK=${2:-/home/martin/Android/Sdk/ndk/25.1.8937393}
+# ABI=${1:-arm64-v8a}
+# NDK=${2:-/home/martin/Android/Sdk/ndk/25.1.8937393}
+echo "Using ABI: ${ABI}"
+echo "Using NDK location: ${NDK}"
+echo "Using architecture: ${ARCH} (compiler prefix: ${COMPILER_PREFIX})"
 
-#export NDK=/home/martin/Android/Sdk/ndk/25.1.8937393
+# Define NDK path and toolchain
 export TOOLCHAIN=$NDK/toolchains/llvm/prebuilt/linux-x86_64
-export TARGET=$ABI-linux-android
+# export TARGET=$ABI-linux-android
+export TARGET=$COMPILER_PREFIX
 export API=21
 
 # Setup Compiler Variables
@@ -17,14 +21,14 @@ export RANLIB=$TOOLCHAIN/bin/llvm-ranlib
 export STRIP=$TOOLCHAIN/bin/llvm-strip
 
 # Setup Additional Flags
-export SYSROOT=$TOOLCHAIN/sysroot
+export SYSROOT="$TOOLCHAIN/sysroot"
 export CFLAGS="--sysroot $SYSROOT"
 export CXXFLAGS="--sysroot $SYSROOT"
 export LDFLAGS="--sysroot $SYSROOT -L$SYSROOT/usr/lib"
 export CPPFLAGS="-I$SYSROOT/usr/include"
 
-
 cd ../zlib/source
-./configure --prefix=$SYSROOT/usr --shared
-make && make install
+echo $PWD
+./configure --prefix="$SYSROOT/usr" --shared
+make && make install && make clean
 cd ../../build_scripts


### PR DESCRIPTION
Hi Martin - I have fixed now the configure scripts to use the correct ABI strings. Now zlib works like a charm, and I get actual compilations errors our of the run. Please test this out.

For a reference which ABI-strings are valid, look at https://developer.android.com/studio/projects/gradle-external-native-builds.